### PR TITLE
fix(require): get rid of relative path to the word-wrap

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "format cjs";
 
-var wrap = require('./node_modules/word-wrap/index');
+var wrap = require('word-wrap');
 
 // This can be any kind of SystemJS compatible module.
 // We use Commonjs here, but ES6 or AMD would do just 


### PR DESCRIPTION
Fix this module for npm@3 where flat directory structure is "by default". A bit of background: If the module identifier passed to require() is not a native module, and does not begin with '/', '../', or './', then Node.js starts at the parent directory of the current module, and adds /node_modules, and attempts to load the module from that location. If it is not found there, then it moves to the parent directory, and so on, until the root of the file system is reached.

This closes #4