### PR TITLE
Remove parentheses when there is no scope present

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,8 +88,12 @@ module.exports = {
         width: maxLineWidth
       };
 
+      // parentheses are only needed when a scope is present
+      var scope = answers.scope.trim();
+      scope = scope ? '(' + answers.scope.trim() + ')' : '';
+
       // Hard limit this line
-      var head = (answers.type + '(' + answers.scope.trim() + '): ' + answers.subject.trim()).slice(0, maxLineWidth);
+      var head = (answers.type + scope + ': ' + answers.subject.trim()).slice(0, maxLineWidth);
 
       // Wrap these lines at 100 characters
       var body = wrap(answers.body, wrapOptions);


### PR DESCRIPTION
This PR removes parentheses when you don't put a scope.

I believe parentheses are not needed when there is no scope, but I can't find this in an official document. There are still commits that do this (https://github.com/angular/angular/commit/3c8fa8c50d820e3317bc40292c73df03c8b23e86) and I think `type(): ...` just looks silly.