### PR TITLE
feat(engine): add ci skip directive for docs/chore

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -32,7 +32,8 @@ module.exports = function (options) {
     //
     // By default, we'll de-indent your commit
     // template and will keep empty lines.
-    prompter: function(cz, commit) {
+    prompter: function (cz, commit) {
+
       console.log('\nLine 1 will be cropped at 100 characters. All other lines will be wrapped after 100 characters.\n');
 
       // Let's ask some questions of the user
@@ -65,7 +66,7 @@ module.exports = function (options) {
           name: 'footer',
           message: 'List any breaking changes or issues closed by this change:\n'
         }
-      ]).then(function(answers) {
+      ]).then(function (answers) {
 
         var maxLineWidth = 100;
 
@@ -80,8 +81,15 @@ module.exports = function (options) {
         var scope = answers.scope.trim();
         scope = scope ? '(' + answers.scope.trim() + ')' : '';
 
+        var ending = answers.subject.trim().slice(-9);
+        var hasSkip = ending === '[ci skip]' || ending === '[skip ci]';
+        var addSkip = !hasSkip && (answers.type === 'docs' || answers.type === 'chore');
+
         // Hard limit this line
-        var head = (answers.type + scope + ': ' + answers.subject.trim()).slice(0, maxLineWidth);
+        var head = (answers.type + scope + ': ' + answers.subject.trim())
+          .slice(0, addSkip ? maxLineWidth - 10 : maxLineWidth);
+
+        if (addSkip) head += ' [ci skip]';
 
         // Wrap these lines at 100 characters
         var body = wrap(answers.body, wrapOptions);

--- a/engine.js
+++ b/engine.js
@@ -5,6 +5,12 @@ var map = require('lodash.map');
 var longest = require('longest');
 var rightPad = require('right-pad');
 
+var filter = function(array) {
+  return array.filter(function(x) {
+    return x;
+  });
+};
+
 // This can be any kind of SystemJS compatible module.
 // We use Commonjs here, but ES6 or AMD would do just
 // fine.
@@ -63,8 +69,12 @@ module.exports = function (options) {
           message: 'Provide a longer description of the change:\n'
         }, {
           type: 'input',
-          name: 'footer',
-          message: 'List any breaking changes or issues closed by this change:\n'
+          name: 'breaking',
+          message: 'List any breaking changes:\n'
+        }, {
+          type: 'input',
+          name: 'issues',
+          message: 'List any issues closed by this change:\n'
         }
       ]).then(function (answers) {
 
@@ -93,7 +103,15 @@ module.exports = function (options) {
 
         // Wrap these lines at 100 characters
         var body = wrap(answers.body, wrapOptions);
-        var footer = wrap(answers.footer, wrapOptions);
+
+        // Apply breaking change prefix, removing it if already present
+        var breaking = answers.breaking.trim();
+        breaking = breaking ? 'BREAKING CHANGE: ' + breaking.replace(/^BREAKING CHANGE: /, '') : '';
+        breaking = wrap(breaking, wrapOptions);
+
+        var issues = wrap(answers.issues, wrapOptions);
+
+        var footer = filter([ breaking, issues ]).join('\n\n');
 
         commit(head + '\n\n' + body + '\n\n' + footer);
       });

--- a/engine.js
+++ b/engine.js
@@ -56,6 +56,14 @@ module.exports = function (options) {
           message: 'Select the type of change that you\'re committing:',
           choices: choices
         }, {
+          type: 'confirm',
+          name: 'skipCI',
+          message: 'Should CI (tests or builds) be skipped for this commit?',
+          default: true,
+          when: function (answers) {
+            return answers.type === 'docs' || answers.type === 'chore'
+          }
+        }, {
           type: 'input',
           name: 'scope',
           message: 'Denote the scope of this change ($location, $browser, $compile, etc.):\n'
@@ -91,9 +99,14 @@ module.exports = function (options) {
         var scope = answers.scope.trim();
         scope = scope ? '(' + answers.scope.trim() + ')' : '';
 
-        var ending = answers.subject.trim().slice(-9);
-        var hasSkip = ending === '[ci skip]' || ending === '[skip ci]';
-        var addSkip = !hasSkip && (answers.type === 'docs' || answers.type === 'chore');
+        var hasSkip = ['[ci skip]', '[skip ci]'].some(v => {
+          return (
+            answers.subject.indexOf(v) > -1 ||
+            answers.body.indexOf(v) > -1
+          )
+        });
+        
+        var addSkip = !hasSkip && answers.skipCI
 
         // Hard limit this line
         var head = (answers.type + scope + ': ' + answers.subject.trim())

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "word-wrap": "^1.0.3"
   },
   "devDependencies": {
-    "commitizen": "2.9.5",
+    "commitizen": "2.9.6",
     "semantic-release": "^6.3.2"
   },
   "czConfig": {


### PR DESCRIPTION
Resolves #23 

Add `[ci skip]` directive automatically for `docs` and `chore` commit types.

- the directive is not added if the user already added `[ci skip]` or `[skip ci]`
- max line width is taken into account when adding the directive

Note that I also made a couple tiny refactoring changes in order to make the code style more consistent, like padding at the beginning of the function block and spacing between function keyword & parens. Both of these had cases of different styles.

---

Also, and this is unrelated to this PR, but what is the lowest Node environment you're supporting? I considered making a separate PR for a light ES2015 upgrade - it wouldn't have any functional differences but the syntax would be a little cleaner in certain places.