### PR TITLE
Removed unused pad-right dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "conventional-commit-types": "^2.0.0",
     "lodash.map": "^4.5.1",
     "longest": "^1.0.1",
-    "pad-right": "^0.2.2",
     "right-pad": "^1.0.1",
     "word-wrap": "^1.0.3"
   },


### PR DESCRIPTION
Saw this in a dependency tree for a project I work on and thought it looked a bit silly that 'pad-right' and 'right-pad' were both present (especially given the history of *-pad in js).