### PR TITLE
feat(prompt): add confirmation fields + edit for clarity

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -11,6 +11,10 @@ var filter = function(array) {
   });
 };
 
+process.on('unhandledRejection', error => {
+  console.log('unhandledRejection', error);
+});
+
 // This can be any kind of SystemJS compatible module.
 // We use Commonjs here, but ES6 or AMD would do just
 // fine.
@@ -57,7 +61,7 @@ module.exports = function (options) {
         }, {
           type: 'input',
           name: 'scope',
-          message: 'Denote the scope of this change ($location, $browser, $compile, etc.):\n'
+          message: 'What is the scope of this change (e.g. component or file name):\n'
         }, {
           type: 'input',
           name: 'subject',
@@ -67,13 +71,29 @@ module.exports = function (options) {
           name: 'body',
           message: 'Provide a longer description of the change:\n'
         }, {
+          type: 'confirm',
+          name: 'isBreaking',
+          message: 'Are there any breaking changes?',
+          default: false
+        }, {
           type: 'input',
           name: 'breaking',
-          message: 'List any breaking changes:\n'
+          message: 'List breaking changes (one per line):\n',
+          when: function(answers) {
+            return answers.isBreaking;
+          }
+        }, {
+          type: 'confirm',
+          name: 'isIssueAffected',
+          message: 'Does this change affect any open issues?',
+          default: false
         }, {
           type: 'input',
           name: 'issues',
-          message: 'List any issues closed by this change:\n'
+          message: 'Add issue references (e.g. "fix #123", "re #123".):\n',
+          when: function(answers) {
+            return answers.isIssueAffected;
+          }
         }
       ]).then(function(answers) {
 
@@ -97,11 +117,11 @@ module.exports = function (options) {
         var body = wrap(answers.body, wrapOptions);
 
         // Apply breaking change prefix, removing it if already present
-        var breaking = answers.breaking.trim();
+        var breaking = answers.breaking ? answers.breaking.trim() : '';
         breaking = breaking ? 'BREAKING CHANGE: ' + breaking.replace(/^BREAKING CHANGE: /, '') : '';
         breaking = wrap(breaking, wrapOptions);
 
-        var issues = wrap(answers.issues, wrapOptions);
+        var issues = answers.issues ? wrap(answers.issues, wrapOptions) : '';
 
         var footer = filter([ breaking, issues ]).join('\n\n');
 

--- a/engine.js
+++ b/engine.js
@@ -11,10 +11,6 @@ var filter = function(array) {
   });
 };
 
-process.on('unhandledRejection', error => {
-  console.log('unhandledRejection', error);
-});
-
 // This can be any kind of SystemJS compatible module.
 // We use Commonjs here, but ES6 or AMD would do just
 // fine.

--- a/engine.js
+++ b/engine.js
@@ -57,7 +57,7 @@ module.exports = function (options) {
         }, {
           type: 'input',
           name: 'scope',
-          message: 'What is the scope of this change (e.g. component or file name):\n'
+          message: 'What is the scope of this change (e.g. component or file name)? (press enter to skip)\n'
         }, {
           type: 'input',
           name: 'subject',
@@ -65,7 +65,7 @@ module.exports = function (options) {
         }, {
           type: 'input',
           name: 'body',
-          message: 'Provide a longer description of the change:\n'
+          message: 'Provide a longer description of the change: (press enter to skip)\n'
         }, {
           type: 'confirm',
           name: 'isBreaking',
@@ -74,7 +74,7 @@ module.exports = function (options) {
         }, {
           type: 'input',
           name: 'breaking',
-          message: 'List breaking changes (one per line):\n',
+          message: 'Describe the breaking changes:\n',
           when: function(answers) {
             return answers.isBreaking;
           }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "commitizen": "2.9.6",
     "semantic-release": "^6.3.2"
   },
-  "czConfig": {
-    "path": "./"
+  "config": {
+    "commitizen" : {
+      "path": "./index.js"
+    }
   }
 }


### PR DESCRIPTION
- Updates `czConfig` to `config` in `package.json`
- Adds `confirm` prompts for breaking changes and referenced issues to prevent accidental major bumps
- Updates questions to help devs less familiar with Angular
- Make it clearer which parts of the commit message are optional

fix #52 