### PR TITLE
feat: line length options

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -26,6 +26,9 @@ module.exports = function (options) {
     };
   });
 
+  var maxHeadWidth = options.maxLineWidths.head;
+  var maxBodyWidth = options.maxLineWidths.body;
+
   return {
     // When a user runs `git cz`, prompter will
     // be executed. We pass you cz, which currently
@@ -39,7 +42,7 @@ module.exports = function (options) {
     // By default, we'll de-indent your commit
     // template and will keep empty lines.
     prompter: function(cz, commit) {
-      console.log('\nLine 1 will be cropped at 100 characters. All other lines will be wrapped after 100 characters.\n');
+      console.log('\nLine 1 will be cropped at ' + maxHeadWidth + ' characters. All other lines will be wrapped after ' + maxBodyWidth + ' characters.\n');
 
       // Let's ask some questions of the user
       // so that we can populate our commit
@@ -93,13 +96,11 @@ module.exports = function (options) {
         }
       ]).then(function(answers) {
 
-        var maxLineWidth = 100;
-
         var wrapOptions = {
           trim: true,
           newline: '\n',
           indent:'',
-          width: maxLineWidth
+          width: maxBodyWidth
         };
 
         // parentheses are only needed when a scope is present
@@ -107,7 +108,7 @@ module.exports = function (options) {
         scope = scope ? '(' + answers.scope.trim() + ')' : '';
 
         // Hard limit this line
-        var head = (answers.type + scope + ': ' + answers.subject.trim()).slice(0, maxLineWidth);
+        var head = (answers.type + scope + ': ' + answers.subject.trim()).slice(0, maxHeadWidth);
 
         // Wrap these lines at 100 characters
         var body = wrap(answers.body, wrapOptions);

--- a/index.js
+++ b/index.js
@@ -3,6 +3,15 @@
 var engine = require('./engine');
 var conventionalCommitTypes = require('conventional-commit-types');
 
+var findConfig = require('find-config');
+var get = require('lodash.get');
+
+var maxLineWidths = get(
+  findConfig.require('package.json', { home: false }),
+  'config.cz-conventional-changelog.maxLineWidths',
+  { head: 100, body: 100 });
+
 module.exports = engine({
-  types: conventionalCommitTypes.types
+  types: conventionalCommitTypes.types,
+  maxLineWidths: maxLineWidths
 });

--- a/index.js
+++ b/index.js
@@ -6,10 +6,11 @@ var conventionalCommitTypes = require('conventional-commit-types');
 var findConfig = require('find-config');
 var get = require('lodash.get');
 
-var maxLineWidths = get(
-  findConfig.require('package.json', { home: false }),
-  'config.cz-conventional-changelog.maxLineWidths',
-  { head: 100, body: 100 });
+var maxLineWidths = Object.assign(
+  { head: 100, body: 100 },
+  get(
+    findConfig.require('package.json', { home: false }),
+    'config.cz-conventional-changelog.maxLineWidths'));
 
 module.exports = engine({
   types: conventionalCommitTypes.types,

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   "license": "MIT",
   "dependencies": {
     "conventional-commit-types": "^2.0.0",
+    "find-config": "^1.0.0",
+    "lodash.get": "^4.4.2",
     "lodash.map": "^4.5.1",
     "longest": "^1.0.1",
     "right-pad": "^1.0.1",


### PR DESCRIPTION
Allow the maximum head (summary) and body widths to be configured in `package.json`

If one or both are not specified, the current default of 100 will be used

close #26