### PR TITLE
feat: add default values to options

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -53,19 +53,23 @@ module.exports = function (options) {
           type: 'list',
           name: 'type',
           message: 'Select the type of change that you\'re committing:',
-          choices: choices
+          choices: choices,
+          default: options.defaultType
         }, {
           type: 'input',
           name: 'scope',
-          message: 'What is the scope of this change (e.g. component or file name)? (press enter to skip)\n'
+          message: 'What is the scope of this change (e.g. component or file name)? (press enter to skip)\n',
+          default: options.defaultScope
         }, {
           type: 'input',
           name: 'subject',
-          message: 'Write a short, imperative tense description of the change:\n'
+          message: 'Write a short, imperative tense description of the change:\n',
+          default: options.defaultSubject
         }, {
           type: 'input',
           name: 'body',
-          message: 'Provide a longer description of the change: (press enter to skip)\n'
+          message: 'Provide a longer description of the change: (press enter to skip)\n',
+          default: options.defaultBody
         }, {
           type: 'confirm',
           name: 'isBreaking',
@@ -82,14 +86,15 @@ module.exports = function (options) {
           type: 'confirm',
           name: 'isIssueAffected',
           message: 'Does this change affect any open issues?',
-          default: false
+          default: options.defaultIssues ? true : false
         }, {
           type: 'input',
           name: 'issues',
           message: 'Add issue references (e.g. "fix #123", "re #123".):\n',
           when: function(answers) {
             return answers.isIssueAffected;
-          }
+          },
+          default: options.defaultIssues ? options.defaultIssues : undefined
         }
       ]).then(function(answers) {
 

--- a/index.js
+++ b/index.js
@@ -4,5 +4,10 @@ var engine = require('./engine');
 var conventionalCommitTypes = require('conventional-commit-types');
 
 module.exports = engine({
-  types: conventionalCommitTypes.types
+  types: conventionalCommitTypes.types,
+  defaultType: process.env.CZ_TYPE,
+  defaultScope: process.env.CZ_SCOPE,
+  defaultSubject: process.env.CZ_SUBJECT,
+  defaultBody: process.env.CZ_BODY,
+  defaultIssues: process.env.CZ_ISSUES
 });


### PR DESCRIPTION
For my own workflow, I made an adapter to allow passing default values in gleaned from the branch name, but needed to somehow get those values into this adapter, and I thought this was a good way to achieve this goal.

With these changes, my custom adapter can be like this:
```
process.env.CZ_TYPE = "fix"
module.exports = require("cz-conventional-changelog")
```

Instead of having to copy everything.