### PR TITLE
style(subject-message): Replace "tense" with "terse"

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -61,7 +61,7 @@ module.exports = function (options) {
         }, {
           type: 'input',
           name: 'subject',
-          message: 'Write a short, imperative tense description of the change:\n'
+          message: 'Write a short, imperative terse description of the change:\n'
         }, {
           type: 'input',
           name: 'body',


### PR DESCRIPTION
Addresses a typo in the commit subject prompt.