### PR TITLE
fix: typo in cli prompt

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -63,7 +63,7 @@ module.exports = function (options) {
         }, {
           type: 'input',
           name: 'subject',
-          message: 'Write a short, imperative tense description of the change:\n',
+          message: 'Write a short, imperative terse description of the change:\n',
           default: options.defaultSubject
         }, {
           type: 'input',


### PR DESCRIPTION
I'm only guessing that the usage of "tense" rather than "terse" is a typo.