### PR TITLE
ci(publish): fixed the npm command to run semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
         provider: script
         skip_cleanup: true
         script:
-          - npm semantic-release
+          - npm run semantic-release
 
 branches:
   only:


### PR DESCRIPTION
added `run` to the `npm` command so that the script would run properly. this should fix the publish problem that i mentioned in https://github.com/commitizen/cz-conventional-changelog/pull/75#issuecomment-484928384