### PR TITLE
feat(engine): add support for disableScopeLowerCase

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -83,7 +83,9 @@ module.exports = function(options) {
             'What is the scope of this change (e.g. component or file name): (press enter to skip)',
           default: options.defaultScope,
           filter: function(value) {
-            return value.trim().toLowerCase();
+            return options.disableScopeLowerCase
+              ? value.trim()
+              : value.trim().toLowerCase();
           }
         },
         {

--- a/engine.test.js
+++ b/engine.test.js
@@ -18,7 +18,6 @@ var defaultOptions = {
 var type = 'func';
 var scope = 'everything';
 var subject = 'testing123';
-var subject2 = 'after the fall, I was gone';
 var longBody =
   'a a aa a aa a aa a aa a aa a aa a aa a aa a aa a aa a aa a aa a aa a aa a' +
   'a a aa a aa a aa a aa a aa a aa a aa a aa a aa a aa a aa a aa a aa a aa a aa a aa a aa a aa a' +
@@ -84,6 +83,23 @@ describe('commit message', function() {
         body
       })
     ).to.equal(`${type}(${scope}): ${subject}\n\n${body}`);
+  });
+  it('header and body w/ uppercase scope', function() {
+    var upperCaseScope = scope.toLocaleUpperCase();
+    expect(
+      commitMessage(
+        {
+          type,
+          scope: upperCaseScope,
+          subject,
+          body
+        },
+        {
+          ...defaultOptions,
+          disableScopeLowerCase: true
+        }
+      )
+    ).to.equal(`${type}(${upperCaseScope}): ${subject}\n\n${body}`);
   });
   it('header, body and issues w/ out scope', function() {
     expect(
@@ -297,6 +313,9 @@ describe('defaults', function() {
         })
       )
     ).to.equal(issues);
+  });
+  it('disableScopeLowerCase default', function() {
+    expect(questionDefault('disableScopeLowerCase')).to.be.undefined;
   });
 });
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ var options = {
   defaultSubject: process.env.CZ_SUBJECT || config.defaultSubject,
   defaultBody: process.env.CZ_BODY || config.defaultBody,
   defaultIssues: process.env.CZ_ISSUES || config.defaultIssues,
+  disableScopeLowerCase:
+    process.env.DISABLE_SCOPE_LOWERCASE || config.disableScopeLowerCase,
   maxHeaderWidth:
     (process.env.CZ_MAX_HEADER_WIDTH &&
       parseInt(process.env.CZ_MAX_HEADER_WIDTH)) ||


### PR DESCRIPTION
Hello Team, 

I am using `commitizen` and `cz-conventional-changelog` with a bunch of front-end projects. The issue that I face is lowerCase with scope. At times I want to maintain the case of `scope` in my commit message for example. `SidePanel`, `BreadCrumbs` etc. This will also help to distinguis between components and higher order functions like `WithSomething` vs `withSomething` 

With this PR, I am adding an `disableScopeLowerCase` to options to retain the user provided case for scope and not auto update it to lowercase.

Note: I also use `npx git-cz` to get the prompt. Let me know if these changes would reflect in the prompt too, maintaining the case or do I have to create another PR in a different package too?
