### PR TITLE
fix(defaultValues): Added fallback for optional default values

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var engine = require('./engine');
 var conventionalCommitTypes = require('conventional-commit-types');
 var configLoader = require('commitizen').configLoader;
 
-var config = configLoader.load();
+var config = configLoader.load() || {};
 var options = {
   types: conventionalCommitTypes.types,
   defaultType: process.env.CZ_TYPE || config.defaultType,


### PR DESCRIPTION
We are using [commitizen](https://github.com/commitizen/cz-cli) and after bumping it to version 4.0.3 that bumped the version of [cz-conventional-changelog](https://github.com/commitizen/cz-conventional-changelog) to version 3.0.1 we started getting the error message `TypeError: Cannot read property 'defaultType' of undefined`.

After some investigating we could track it to the default values introduced in PR [#69](https://github.com/commitizen/cz-conventional-changelog/pull/69).

This PR makes it so the default values are optional and safeguards so if no default values are present it does not crash.