### PR TITLE
feat(types): add support for custom types

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,30 @@ Like commitizen, you specify the configuration of cz-conventional-changelog thro
                 "title": "Features"
               },
               ...
-            }
+            },
+            "additionalTypes": {}
         }
     }
 // ...
 }
 ```
+
+The `additionalTypes` property can be used to add custom types in addition to those defined by **conventional-commit-types**:
+
+```json5
+    "config": {
+        "commitizen": {
+            "path": "./node_modules/cz-conventional-changelog",
+            "additionalTypes": {
+                "mycustomtype": {
+                    "description": "A custom commit type for custom changes",
+                    "title": "My Custom Changes"
+                }
+            }
+        }
+    }
+```
+
 ### Environment variables
 
 The following environment varibles can be used to override any default configuration or package.json based configuration.

--- a/README.md
+++ b/README.md
@@ -26,14 +26,7 @@ Like commitizen, you specify the configuration of cz-conventional-changelog thro
             "defaultSubject": "",
             "defaultBody": "",
             "defaultIssues": "",
-            "types": {
-              ...
-              "feat": {
-                "description": "A new feature",
-                "title": "Features"
-              },
-              ...
-            },
+            "types": null,
             "additionalTypes": {}
         }
     }
@@ -41,7 +34,24 @@ Like commitizen, you specify the configuration of cz-conventional-changelog thro
 }
 ```
 
-The `additionalTypes` property can be used to add custom types in addition to those defined by **conventional-commit-types**:
+The `types` property can be used to *replace* the types defined by **conventional-commit-types**:
+
+```json5
+    "config": {
+        "commitizen": {
+            "types": {
+                ...
+                "feat": {
+                    "description": "A new feature",
+                    "title": "Features"
+                },
+                ...
+            }
+        }
+    }
+```
+
+The `additionalTypes` property can be used to add custom types in *addition to* those defined by **conventional-commit-types**:
 
 ```json5
     "config": {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,11 @@ var configLoader = require('commitizen').configLoader;
 
 var config = configLoader.load() || {};
 var options = {
-  types: config.types || conventionalCommitTypes.types,
+  types: Object.assign(
+    {},
+    config.types || conventionalCommitTypes.types,
+    config.additionalTypes
+  ),
   defaultType: process.env.CZ_TYPE || config.defaultType,
   defaultScope: process.env.CZ_SCOPE || config.defaultScope,
   defaultSubject: process.env.CZ_SUBJECT || config.defaultSubject,


### PR DESCRIPTION
Inspired by #104, but slightly different implementation that doesn't require specifying all types just to add one or more custom ones.

The limitation in this implementation is that, while types defined in **conventional-commit-types** can be overridden, they cannot be removed entirely.

fix #93