### PR TITLE
Include "disableScopeLowerCase" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Like commitizen, you specify the configuration of cz-conventional-changelog thro
     "config": {
         "commitizen": {
             "path": "./node_modules/cz-conventional-changelog",
+            "disableScopeLowerCase": false,
             "maxHeaderWidth": 100,
             "maxLineWidth": 100,
             "defaultType": "",


### PR DESCRIPTION
Hi! The "disableScopeLowerCase" key was missing from the configuration specification. I'm glad we can disable this feature because it makes file names in PascalCase or camelCase readable.