### PR TITLE
feat(engine): add support for disableSubjectLowerCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Like commitizen, you specify the configuration of cz-conventional-changelog thro
     "config": {
         "commitizen": {
             "path": "./node_modules/cz-conventional-changelog",
+            "disableScopeLowerCase": false,
+            "disableSubjectLowerCase": false,
             "maxHeaderWidth": 100,
             "maxLineWidth": 100,
             "defaultType": "",
@@ -39,6 +41,7 @@ Like commitizen, you specify the configuration of cz-conventional-changelog thro
 // ...
 }
 ```
+
 ### Environment variables
 
 The following environment varibles can be used to override any default configuration or package.json based configuration.
@@ -53,4 +56,3 @@ The following environment varibles can be used to override any default configura
 ### Commitlint
 
 If using the [commitlint](https://github.com/conventional-changelog/commitlint) js library, the "maxHeaderWidth" configuration property will default to the configuration of the "header-max-length" rule instead of the hard coded value of 100.  This can be ovewritten by setting the 'maxHeaderWidth' configuration in package.json or the CZ_MAX_HEADER_WIDTH environment variable.
-

--- a/engine.js
+++ b/engine.js
@@ -21,9 +21,9 @@ var maxSummaryLength = function(options, answers) {
   return options.maxHeaderWidth - headerLength(answers);
 };
 
-var filterSubject = function(subject) {
+var filterSubject = function(subject, disableSubjectLowerCase) {
   subject = subject.trim();
-  if (subject.charAt(0).toLowerCase() !== subject.charAt(0)) {
+  if (!disableSubjectLowerCase && subject.charAt(0).toLowerCase() !== subject.charAt(0)) {
     subject =
       subject.charAt(0).toLowerCase() + subject.slice(1, subject.length);
   }
@@ -99,7 +99,7 @@ module.exports = function(options) {
           },
           default: options.defaultSubject,
           validate: function(subject, answers) {
-            var filteredSubject = filterSubject(subject);
+            var filteredSubject = filterSubject(subject, options.disableSubjectLowerCase);
             return filteredSubject.length == 0
               ? 'subject is required'
               : filteredSubject.length <= maxSummaryLength(options, answers)
@@ -111,7 +111,7 @@ module.exports = function(options) {
                 ' characters.';
           },
           transformer: function(subject, answers) {
-            var filteredSubject = filterSubject(subject);
+            var filteredSubject = filterSubject(subject, options.disableSubjectLowerCase);
             var color =
               filteredSubject.length <= maxSummaryLength(options, answers)
                 ? chalk.green
@@ -119,7 +119,7 @@ module.exports = function(options) {
             return color('(' + filteredSubject.length + ') ' + subject);
           },
           filter: function(subject) {
-            return filterSubject(subject);
+            return filterSubject(subject, options.disableSubjectLowerCase);
           }
         },
         {

--- a/engine.test.js
+++ b/engine.test.js
@@ -101,6 +101,23 @@ describe('commit message', function() {
       )
     ).to.equal(`${type}(${upperCaseScope}): ${subject}\n\n${body}`);
   });
+  it('header and body w/ uppercase subject', function() {
+    var upperCaseSubject = subject.toLocaleUpperCase();
+    expect(
+      commitMessage(
+        {
+          type,
+          scope,
+          subject: upperCaseSubject,
+          body
+        },
+        {
+          ...defaultOptions,
+          disableSubjectLowerCase: true
+        }
+      )
+    ).to.equal(`${type}(${scope}): ${upperCaseSubject}\n\n${body}`);
+  });
   it('header, body and issues w/ out scope', function() {
     expect(
       commitMessage({
@@ -316,6 +333,9 @@ describe('defaults', function() {
   });
   it('disableScopeLowerCase default', function() {
     expect(questionDefault('disableScopeLowerCase')).to.be.undefined;
+  });
+  it('disableSubjectLowerCase default', function() {
+    expect(questionDefault('disableSubjectLowerCase')).to.be.undefined;
   });
 });
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,8 @@ var options = {
   defaultIssues: process.env.CZ_ISSUES || config.defaultIssues,
   disableScopeLowerCase:
     process.env.DISABLE_SCOPE_LOWERCASE || config.disableScopeLowerCase,
+  disableSubjectLowerCase:
+    process.env.DISABLE_SUBJECT_LOWERCASE || config.disableSubjectLowerCase,
   maxHeaderWidth:
     (process.env.CZ_MAX_HEADER_WIDTH &&
       parseInt(process.env.CZ_MAX_HEADER_WIDTH)) ||


### PR DESCRIPTION
this PR is basically identical to #96 , but sopport for `disableSubjectLowerCase`.

for example, I have a monorepo project, and the scope is the package name, so I would like to commit message like this:

`fix(packageA): ReactComponent support new props`
