### PR TITLE
feat: recognise all-caps strings in the subject

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -17,13 +17,31 @@ var headerLength = function(answers) {
   );
 };
 
+var isLetter = function(character) {
+  if (typeof character !== "string" || !character.trim()) {
+    return false
+  }
+  return character.toUpperCase() !== character.toLowerCase();
+}
+
+var isUppercaseLetter = function(character) {
+  if (typeof character !== "string" || !character.trim()) {
+    return false
+  }
+  return character === character.toUpperCase();
+}
+
 var maxSummaryLength = function(options, answers) {
   return options.maxHeaderWidth - headerLength(answers);
 };
 
 var filterSubject = function(subject, disableSubjectLowerCase) {
   subject = subject.trim();
-  if (!disableSubjectLowerCase && subject.charAt(0).toLowerCase() !== subject.charAt(0)) {
+  if (
+    !disableSubjectLowerCase &&
+    subject.charAt(0).toLowerCase() !== subject.charAt(0) &&
+    (!subject.charAt(1) || !isLetter(subject.charAt(1)) || !isUppercaseLetter(subject.charAt(1)))
+  ) {
     subject =
       subject.charAt(0).toLowerCase() + subject.slice(1, subject.length);
   }

--- a/engine.test.js
+++ b/engine.test.js
@@ -101,6 +101,53 @@ describe('commit message', function() {
       )
     ).to.equal(`${type}(${upperCaseScope}): ${subject}\n\n${body}`);
   });
+  it('all caps subject, disableSubjectLowerCase off', function() {
+    var allCapsSubject = `XML changes`;
+    expect(
+      commitMessage(
+        {
+          type,
+          scope,
+          subject: allCapsSubject,
+          body
+        },
+        {
+          ...defaultOptions,
+          disableSubjectLowerCase: false // <---
+        }
+      )
+    ).to.equal(`${type}(${scope}): ${allCapsSubject}\n\n${body}`);
+  });
+  it('all caps subject, disableSubjectLowerCase on', function() {
+    var allCapsSubject = `XML changes`;
+    expect(
+      commitMessage(
+        {
+          type,
+          scope,
+          subject: allCapsSubject,
+          body
+        },
+        {
+          ...defaultOptions,
+          disableSubjectLowerCase: true // <---
+        }
+      )
+    ).to.equal(`${type}(${scope}): ${allCapsSubject}\n\n${body}`);
+  });
+  it('subject starts with number', function() {
+    var subjectWithNumber = `2nd iteration`;
+    expect(
+      commitMessage(
+        {
+          type,
+          scope,
+          subject: subjectWithNumber,
+          body
+        }
+      )
+    ).to.equal(`${type}(${scope}): ${subjectWithNumber}\n\n${body}`);
+  });
   it('header and body w/ uppercase subject', function() {
     var upperCaseSubject = subject.toLocaleUpperCase();
     expect(


### PR DESCRIPTION
fixes #102 — if subject's second character is a letter and it's an uppercase letter, NOW first character is not upper-cased, no matter the setting.

I've got bitten by this few times, when mentioning "HTML" or "XML" or "CSS" in the subject :)

Please review, feel free to edit. I added tests.

Thank you.