### PR TITLE
feat(engine): add support for custom scopes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,33 @@ Like commitizen, you specify the configuration of cz-conventional-changelog thro
                 "title": "Features"
               },
               ...
-            }
+            },
+            "scopes": {}
         }
     }
 // ...
+}
+```
+
+#### Custom Scopes
+
+Following the example for custom types, you can build custom scopes in the package.json's `config.commitizen` key.
+
+```json5
+{
+  // ...
+  "config": {
+    "commitizen": {
+      "scopes": {
+        ...
+        "config": {
+          "description": "A configuration level change",
+          "title": "Configuration"
+        },
+        ...
+      }
+    }
+  }
 }
 ```
 

--- a/engine.js
+++ b/engine.js
@@ -33,20 +33,21 @@ var filterSubject = function(subject, disableSubjectLowerCase) {
   return subject;
 };
 
+var mapToInquirerChoices = function (definitions) {
+  var maxLength = longest(Object.keys(definitions)).length + 1;
+  return map(definitions, function (definition, key) {
+    return {
+      name: (key + ':').padEnd(maxLength) + ' ' + definition.description,
+      value: key,
+    }
+  });
+};
+
 // This can be any kind of SystemJS compatible module.
 // We use Commonjs here, but ES6 or AMD would do just
 // fine.
 module.exports = function(options) {
-  var types = options.types;
-
-  var length = longest(Object.keys(types)).length + 1;
-  var choices = map(types, function(type, key) {
-    return {
-      name: (key + ':').padEnd(length) + ' ' + type.description,
-      value: key
-    };
-  });
-
+  var isUsingCustomScopes = options.scopes && Object.keys(options.scopes).length > 0;
   return {
     // When a user runs `git cz`, prompter will
     // be executed. We pass you cz, which currently
@@ -72,10 +73,16 @@ module.exports = function(options) {
           type: 'list',
           name: 'type',
           message: "Select the type of change that you're committing:",
-          choices: choices,
+          choices: mapToInquirerChoices(options.types),
           default: options.defaultType
         },
-        {
+        isUsingCustomScopes ? {
+          type: 'list',
+          name: 'scope',
+          message: "Select the scope of the change that you're committing:",
+          choices: mapToInquirerChoices(options.scopes),
+          default: options.defaultScope
+        } : {
           type: 'input',
           name: 'scope',
           message:

--- a/engine.test.js
+++ b/engine.test.js
@@ -355,6 +355,21 @@ describe('prompts', function() {
   });
 });
 
+describe('scope', function () {
+  it('commit scope prompts with input when scopes option is undefined', function () {
+    expect(getQuestion('scope', { types })).to.have.property('type', 'input');
+  });
+  it('commit scope prompts with list when scopes option is defined', function () {
+    var scopes = {
+      config: {
+        description: 'Configuration',
+        title: 'Configuration',
+      }
+    };
+    expect(getQuestion('scope', { types, scopes })).to.have.property('type', 'list');
+  });
+});
+
 describe('transformation', function() {
   it('subject w/ character count', () =>
     expect(

--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ var options = {
     (process.env.CZ_MAX_LINE_WIDTH &&
       parseInt(process.env.CZ_MAX_LINE_WIDTH)) ||
     config.maxLineWidth ||
-    100
+    100,
+  scopes: config.scopes || {}
 };
 
 (function(options) {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,21 @@
   },
   "config": {
     "commitizen": {
-      "path": "./index.js"
+      "path": "./index.js",
+      "scopes": {
+        "deps": {
+          "description": "Depedency changes",
+          "title": "Dependencies"
+        },
+        "engine": {
+          "description": "Engine-level changes",
+          "title": "Engine"
+        },
+        "readme": {
+          "description": "README changes",
+          "title": "README"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This change is to support the custom scopes definition in the package.json's `config.commitizen.scopes` key. The format of the key matches the format of the `config.commitizen.types` key. Each scope has a `description` and `title` key used by inquirer to display the scope to the user. In order to maintain backward-compatibility, the default value for the new package.json key (i.e., `scopes`) is an empty JSON object. When no keys are present in this object, we will default to custom user input for the scope. This also includes the option to press Enter to skip.

refs: #213

https://github.com/commitizen/cz-conventional-changelog/assets/24667860/bccddf21-2fe2-450b-b3ca-72709b61ae82

