### PR TITLE
docs(readme): add missing CZ_ISSUES defaultIssues line

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The following environment variables can be used to override any default configur
 * CZ_SCOPE = defaultScope
 * CZ_SUBJECT = defaultSubject
 * CZ_BODY = defaultBody
+* CZ_ISSUES = defaultIssues
 * CZ_MAX_HEADER_WIDTH = maxHeaderWidth
 * CZ_MAX_LINE_WIDTH = maxLineWidth
 


### PR DESCRIPTION
The README was missing the `defaultIssues` value for the CZ_ISSUES configuration.

This PR adds the missing line to clarify usage for users configuring Commitizen, and improves visibility so it can be found more easily next time.

Reference: [defaultIssues: process.env.CZ_ISSUES || config.defaultIssues,](https://github.com/commitizen/cz-conventional-changelog/blob/56868397bd544935a6d1036b39a3dd7dab09bb1d/index.js#L14)