### PR TITLE
refactor: remove micro-util dependencies

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1,7 +1,6 @@
 'format cjs';
 
 var wrap = require('word-wrap');
-var longest = require('longest');
 var chalk = require('chalk');
 
 var filter = function(array) {
@@ -32,12 +31,24 @@ var filterSubject = function(subject, disableSubjectLowerCase) {
   return subject;
 };
 
+/**
+ * @param input {string[]}
+ * @return {number}
+ */
+function getLongestLength(input) {
+  var longest = Object.keys(input).reduce(function(maxLength, key) {
+    return Math.max(maxLength, key.length);
+  }, 0);
+
+  return longest + 1;
+}
+
 // This can be any kind of SystemJS compatible module.
 // We use Commonjs here, but ES6 or AMD would do just
 // fine.
 module.exports = function(options) {
   var keys = Object.keys(options.types);
-  var length = longest(keys).length + 1;
+  var length = getLongestLength(keys);
   var choices = keys.map(function(key) {
     return {
       name: (key + ':').padEnd(length) + ' ' + options.types[key].description,

--- a/engine.js
+++ b/engine.js
@@ -1,7 +1,6 @@
 'format cjs';
 
 var wrap = require('word-wrap');
-var map = require('lodash.map');
 var longest = require('longest');
 var chalk = require('chalk');
 
@@ -37,12 +36,11 @@ var filterSubject = function(subject, disableSubjectLowerCase) {
 // We use Commonjs here, but ES6 or AMD would do just
 // fine.
 module.exports = function(options) {
-  var types = options.types;
-
-  var length = longest(Object.keys(types)).length + 1;
-  var choices = map(types, function(type, key) {
+  var keys = Object.keys(options.types);
+  var length = longest(keys).length + 1;
+  var choices = keys.map(function(key) {
     return {
-      name: (key + ':').padEnd(length) + ' ' + type.description,
+      name: (key + ':').padEnd(length) + ' ' + options.types[key].description,
       value: key
     };
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "chalk": "^4.1.2",
         "commitizen": "^4.3.1",
         "conventional-commit-types": "^3.0.0",
-        "lodash.map": "^4.6.0",
         "longest": "^2.0.1",
         "word-wrap": "^1.2.5"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "chalk": "^4.1.2",
         "commitizen": "^4.3.1",
         "conventional-commit-types": "^3.0.0",
-        "longest": "^2.0.1",
         "word-wrap": "^1.2.5"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "chalk": "^4.1.2",
     "commitizen": "^4.3.1",
     "conventional-commit-types": "^3.0.0",
-    "longest": "^2.0.1",
     "word-wrap": "^1.2.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "chalk": "^4.1.2",
     "commitizen": "^4.3.1",
     "conventional-commit-types": "^3.0.0",
-    "lodash.map": "^4.6.0",
     "longest": "^2.0.1",
     "word-wrap": "^1.2.5"
   },


### PR DESCRIPTION
This PR replaces `lodash.map` and `longest` with `Array.map()` and a small utility function.

---

I saw you talking about various issues due to the package being old (#225, #227). I would be up for helping out if you want
I've seen various things that could be done in this and its related packages, feel free to let me know what you think about these ideas (maybe even in its own issue? 😋):

- Replace various micro-utilities with native JS or simple functions (like this PR!)
- Replace `chalk` with `picocolors` as it's the one generally used by modern packages like vite
- Upgrade minimum Node version to 20 (since it would allow...)
- Migrating to ESM
- Using node's native test runner instead of mocha
